### PR TITLE
fix deleted notes not detached from lanes

### DIFF
--- a/kanban_app/app/actions/lanes.js
+++ b/kanban_app/app/actions/lanes.js
@@ -37,6 +37,15 @@ export function attachToLane(laneId, noteId) {
   };
 };
 
+export const DETACH_FROM_LANE = 'DETACH_FROM_LANE';
+export function detachFromLane(laneId, noteId) {
+  return {
+    type: DETACH_FROM_LANE,
+    laneId,
+    noteId
+  };
+};
+
 export const MOVE = 'MOVE';
 export function move({sourceId, targetId}) {
   return {

--- a/kanban_app/app/components/Lane.jsx
+++ b/kanban_app/app/components/Lane.jsx
@@ -56,7 +56,7 @@ export default class Lane extends React.Component {
           notes={laneNotes}
           onValueClick={id => props.updateNote({id, editing: true})}
           onEdit={(id, task) => props.updateNote({id, task, editing: false})}
-          onDelete={noteId => props.deleteNote(noteId)} />
+          onDelete={id => this.deleteNote(laneId, id)} />
       </div>
     );
   }
@@ -67,5 +67,9 @@ export default class Lane extends React.Component {
       task: 'New task'
     });
     this.props.attachToLane(laneId, o.note.id);
+  }
+  deleteNote(laneId, noteId) {
+    this.props.detachFromLane(laneId, noteId);
+    this.props.deleteNote(noteId);
   }
 }

--- a/kanban_app/app/reducers/lanes.js
+++ b/kanban_app/app/reducers/lanes.js
@@ -43,6 +43,17 @@ export default function lanes(state = initialState, action) {
         return lane;
       });
 
+    case types.DETACH_FROM_LANE:
+      return state.map((lane) => {
+        if(lane.id === action.laneId) {
+          return Object.assign({}, lane, {
+            notes: lane.notes.filter((id) => id !== action.noteId)
+          });
+        }
+
+        return lane;
+      });
+
     case types.MOVE:
       const sourceId = action.sourceId;
       const targetId = action.targetId;


### PR DESCRIPTION
this follows the implementation in the main app for the book, otherwise
stale references to notes are left in the lanes store upon note deletion.
