### PR TITLE
Replaced with the correct index

### DIFF
--- a/kanban_app/app/reducers/lanes.js
+++ b/kanban_app/app/reducers/lanes.js
@@ -94,10 +94,10 @@ export default function lanes(state = initialState, action) {
           if(lane === targetLane) {
             // and move it to target
             return Object.assign({}, lane, {
-              notes: lane.notes.slice(0, sourceNoteIndex).concat(
+              notes: lane.notes.slice(0, targetNoteIndex).concat(
                 [sourceId]
               ).concat(
-                lane.notes.slice(sourceNoteIndex)
+                lane.notes.slice(targetNoteIndex)
               )
             });
           }


### PR DESCRIPTION
When dragging a note from one lane to another, `targetNoteIndex` is the correct index number at which inserting the `sourceId`. In fact this is shown correctly in the [tutorial](https://github.com/survivejs/webpack_react/blob/dev/project_source/07_implementing_dnd/kanban_app/app/stores/LaneStore.js#L90).

``` javascript
else {
      // get rid of the source
      sourceLane.notes.splice(sourceNoteIndex, 1);

      // and move it to target
      targetLane.notes.splice(targetNoteIndex, 0, sourceId);
```
